### PR TITLE
Allow DICOM MCP to receive dataset send from a C-move

### DIFF
--- a/src/dicom_mcp/config.py
+++ b/src/dicom_mcp/config.py
@@ -4,7 +4,7 @@ DICOM configuration using Pydantic.
 
 import yaml
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 from pydantic import BaseModel
 
 
@@ -21,16 +21,17 @@ class DicomConfiguration(BaseModel):
     nodes: Dict[str, DicomNodeConfig]
     current_node: str
     calling_aet: str
+    scp_port: Optional[int] = None
 
 def load_config(config_path: str) -> DicomConfiguration:
     """Load DICOM configuration from YAML file.
-    
+
     Args:
         config_path: Path to the configuration file
-        
+
     Returns:
         Parsed DicomConfiguration object
-        
+
     Raises:
         FileNotFoundError: If the configuration file doesn't exist
         ValueError: If the configuration is invalid
@@ -38,10 +39,10 @@ def load_config(config_path: str) -> DicomConfiguration:
     path = Path(config_path)
     if not path.exists():
         raise FileNotFoundError(f"Configuration file {path} not found")
-    
+
     with open(path, 'r') as f:
         data = yaml.safe_load(f)
-    
+
     try:
         return DicomConfiguration(**data)
     except Exception as e:

--- a/src/dicom_mcp/dicom_client.py
+++ b/src/dicom_mcp/dicom_client.py
@@ -26,6 +26,7 @@ from pynetdicom.sop_class import (
 
 from .attributes import get_attributes_for_level
 from .config import DicomConfiguration
+from .dicom_storage import DicomStorage
 
 class DicomClient:
     """DICOM networking client that handles communication with DICOM nodes."""
@@ -62,6 +63,8 @@ class DicomClient:
 
         # Add specific storage context for PDF - instead of adding all storage contexts
         self.ae.add_requested_context(EncapsulatedPDFStorage)
+
+        self.storage = DicomStorage(config, logger)
 
     def verify_connection(self) -> Tuple[bool, str]:
         """Verify connectivity to the DICOM node using C-ECHO.

--- a/src/dicom_mcp/dicom_client.py
+++ b/src/dicom_mcp/dicom_client.py
@@ -4,6 +4,7 @@ DICOM Client.
 This module provides a clean interface to pynetdicom functionality,
 abstracting the details of DICOM networking.
 """
+from logging import Logger
 import os
 import time
 import tempfile
@@ -24,27 +25,32 @@ from pynetdicom.sop_class import (
 )
 
 from .attributes import get_attributes_for_level
+from .config import DicomConfiguration
 
 class DicomClient:
     """DICOM networking client that handles communication with DICOM nodes."""
-    
-    def __init__(self, host: str, port: int, calling_aet: str, called_aet: str):
+
+    def __init__(self, config: DicomConfiguration, logger: Logger):
         """Initialize DICOM client.
-        
+
         Args:
             host: DICOM node hostname or IP
             port: DICOM node port
             calling_aet: Local AE title (our AE title)
             called_aet: Remote AE title (the node we're connecting to)
         """
-        self.host = host
-        self.port = port
-        self.called_aet = called_aet
-        self.calling_aet = calling_aet
-        
+        self.logger = logger
+
+        current_node = config.nodes[config.current_node]
+
+        self.host = current_node.host
+        self.port = current_node.port
+        self.called_aet = current_node.ae_title
+        self.calling_aet = config.calling_aet
+
         # Create the Application Entity
-        self.ae = AE(ae_title=calling_aet)
-        
+        self.ae = AE(ae_title=current_node.ae_title)
+
         # Add the necessary presentation contexts
         self.ae.add_requested_context(Verification)
         self.ae.add_requested_context(PatientRootQueryRetrieveInformationModelFind)
@@ -53,58 +59,58 @@ class DicomClient:
         self.ae.add_requested_context(StudyRootQueryRetrieveInformationModelFind)
         self.ae.add_requested_context(StudyRootQueryRetrieveInformationModelGet)
         self.ae.add_requested_context(StudyRootQueryRetrieveInformationModelMove)
-        
+
         # Add specific storage context for PDF - instead of adding all storage contexts
         self.ae.add_requested_context(EncapsulatedPDFStorage)
-    
+
     def verify_connection(self) -> Tuple[bool, str]:
         """Verify connectivity to the DICOM node using C-ECHO.
-        
+
         Returns:
             Tuple of (success, message)
         """
         # Associate with the DICOM node
         assoc = self.ae.associate(self.host, self.port, ae_title=self.called_aet)
-        
+
         if assoc.is_established:
             # Send C-ECHO request
             status = assoc.send_c_echo()
-            
+
             # Release the association
             assoc.release()
-            
+
             if status and status.Status == 0:
                 return True, f"Connection successful to {self.host}:{self.port} (Called AE: {self.called_aet}, Calling AE: {self.calling_aet})"
             else:
                 return False, f"C-ECHO failed with status: {status.Status if status else 'None'}"
         else:
             return False, f"Failed to associate with DICOM node at {self.host}:{self.port} (Called AE: {self.called_aet}, Calling AE: {self.calling_aet})"
-    
+
     def find(self, query_dataset: Dataset, query_model) -> List[Dict[str, Any]]:
         """Execute a C-FIND request.
-        
+
         Args:
             query_dataset: Dataset containing query parameters
             query_model: DICOM query model (Patient/StudyRoot)
-        
+
         Returns:
             List of dictionaries containing query results
-        
+
         Raises:
             Exception: If association fails
         """
         # Associate with the DICOM node
         assoc = self.ae.associate(self.host, self.port, ae_title=self.called_aet)
-        
+
         if not assoc.is_established:
             raise Exception(f"Failed to associate with DICOM node at {self.host}:{self.port} (Called AE: {self.called_aet}, Calling AE: {self.calling_aet})")
-        
+
         results = []
-        
+
         try:
             # Send C-FIND request
             responses = assoc.send_c_find(query_dataset, query_model)
-            
+
             for (status, dataset) in responses:
                 if status and status.Status == 0xFF00:  # Pending
                     if dataset:
@@ -112,14 +118,14 @@ class DicomClient:
         finally:
             # Always release the association
             assoc.release()
-        
+
         return results
-    
-    def query_patient(self, patient_id: str = None, name_pattern: str = None, 
+
+    def query_patient(self, patient_id: str = None, name_pattern: str = None,
                      birth_date: str = None, attribute_preset: str = "standard",
                      additional_attrs: List[str] = None, exclude_attrs: List[str] = None) -> List[Dict[str, Any]]:
         """Query for patients matching criteria.
-        
+
         Args:
             patient_id: Patient ID
             name_pattern: Patient name pattern (can include wildcards * and ?)
@@ -127,40 +133,40 @@ class DicomClient:
             attribute_preset: Attribute preset (minimal, standard, extended)
             additional_attrs: Additional attributes to include
             exclude_attrs: Attributes to exclude
-            
+
         Returns:
             List of matching patient records
         """
         # Create query dataset
         ds = Dataset()
         ds.QueryRetrieveLevel = "PATIENT"
-        
+
         # Add query parameters if provided
         if patient_id:
             ds.PatientID = patient_id
-            
+
         if name_pattern:
             ds.PatientName = name_pattern
-            
+
         if birth_date:
             ds.PatientBirthDate = birth_date
-        
+
         # Add attributes based on preset
         attrs = get_attributes_for_level("patient", attribute_preset, additional_attrs, exclude_attrs)
         for attr in attrs:
             if not hasattr(ds, attr):
                 setattr(ds, attr, "")
-        
+
         # Execute query
         return self.find(ds, PatientRootQueryRetrieveInformationModelFind)
-    
-    def query_study(self, patient_id: str = None, study_date: str = None, 
-                   modality: str = None, study_description: str = None, 
+
+    def query_study(self, patient_id: str = None, study_date: str = None,
+                   modality: str = None, study_description: str = None,
                    accession_number: str = None, study_instance_uid: str = None,
-                   attribute_preset: str = "standard", additional_attrs: List[str] = None, 
+                   attribute_preset: str = "standard", additional_attrs: List[str] = None,
                    exclude_attrs: List[str] = None) -> List[Dict[str, Any]]:
         """Query for studies matching criteria.
-        
+
         Args:
             patient_id: Patient ID
             study_date: Study date or range (YYYYMMDD or YYYYMMDD-YYYYMMDD)
@@ -171,48 +177,48 @@ class DicomClient:
             attribute_preset: Attribute preset (minimal, standard, extended)
             additional_attrs: Additional attributes to include
             exclude_attrs: Attributes to exclude
-            
+
         Returns:
             List of matching study records
         """
         # Create query dataset
         ds = Dataset()
         ds.QueryRetrieveLevel = "STUDY"
-        
+
         # Add query parameters if provided
         if patient_id:
             ds.PatientID = patient_id
-            
+
         if study_date:
             ds.StudyDate = study_date
-            
+
         if modality:
             ds.ModalitiesInStudy = modality
-            
+
         if study_description:
             ds.StudyDescription = study_description
-            
+
         if accession_number:
             ds.AccessionNumber = accession_number
-            
+
         if study_instance_uid:
             ds.StudyInstanceUID = study_instance_uid
-        
+
         # Add attributes based on preset
         attrs = get_attributes_for_level("study", attribute_preset, additional_attrs, exclude_attrs)
         for attr in attrs:
             if not hasattr(ds, attr):
                 setattr(ds, attr, "")
-        
+
         # Execute query
         return self.find(ds, StudyRootQueryRetrieveInformationModelFind)
-    
+
     def query_series(self, study_instance_uid: str, series_instance_uid: str = None,
-                    modality: str = None, series_number: str = None, 
+                    modality: str = None, series_number: str = None,
                     series_description: str = None, attribute_preset: str = "standard",
                     additional_attrs: List[str] = None, exclude_attrs: List[str] = None) -> List[Dict[str, Any]]:
         """Query for series matching criteria.
-        
+
         Args:
             study_instance_uid: Study Instance UID (required)
             series_instance_uid: Series Instance UID
@@ -222,7 +228,7 @@ class DicomClient:
             attribute_preset: Attribute preset (minimal, standard, extended)
             additional_attrs: Additional attributes to include
             exclude_attrs: Attributes to exclude
-            
+
         Returns:
             List of matching series records
         """
@@ -230,34 +236,34 @@ class DicomClient:
         ds = Dataset()
         ds.QueryRetrieveLevel = "SERIES"
         ds.StudyInstanceUID = study_instance_uid
-        
+
         # Add query parameters if provided
         if series_instance_uid:
             ds.SeriesInstanceUID = series_instance_uid
-            
+
         if modality:
             ds.Modality = modality
-            
+
         if series_number:
             ds.SeriesNumber = series_number
-            
+
         if series_description:
             ds.SeriesDescription = series_description
-        
+
         # Add attributes based on preset
         attrs = get_attributes_for_level("series", attribute_preset, additional_attrs, exclude_attrs)
         for attr in attrs:
             if not hasattr(ds, attr):
                 setattr(ds, attr, "")
-        
+
         # Execute query
         return self.find(ds, StudyRootQueryRetrieveInformationModelFind)
-    
+
     def query_instance(self, series_instance_uid: str, sop_instance_uid: str = None,
                       instance_number: str = None, attribute_preset: str = "standard",
                       additional_attrs: List[str] = None, exclude_attrs: List[str] = None) -> List[Dict[str, Any]]:
         """Query for instances matching criteria.
-        
+
         Args:
             series_instance_uid: Series Instance UID (required)
             sop_instance_uid: SOP Instance UID
@@ -265,7 +271,7 @@ class DicomClient:
             attribute_preset: Attribute preset (minimal, standard, extended)
             additional_attrs: Additional attributes to include
             exclude_attrs: Attributes to exclude
-            
+
         Returns:
             List of matching instance records
         """
@@ -273,37 +279,37 @@ class DicomClient:
         ds = Dataset()
         ds.QueryRetrieveLevel = "IMAGE"
         ds.SeriesInstanceUID = series_instance_uid
-        
+
         # Add query parameters if provided
         if sop_instance_uid:
             ds.SOPInstanceUID = sop_instance_uid
-            
+
         if instance_number:
             ds.InstanceNumber = instance_number
-        
+
         # Add attributes based on preset
         attrs = get_attributes_for_level("instance", attribute_preset, additional_attrs, exclude_attrs)
         for attr in attrs:
             if not hasattr(ds, attr):
                 setattr(ds, attr, "")
-        
+
         # Execute query
         return self.find(ds, StudyRootQueryRetrieveInformationModelFind)
-    
+
     def move_series(
-            self, 
+            self,
             destination_ae: str,
             series_instance_uid: str
         ) -> dict:
         """Move a DICOM series to another DICOM node using C-MOVE.
-        
+
         This method performs a simple C-MOVE operation to transfer a specific series
         to a destination DICOM node.
-        
+
         Args:
             destination_ae: AE title of the destination DICOM node
             series_instance_uid: Series Instance UID to be moved
-            
+
         Returns:
             Dictionary with operation status:
             {
@@ -318,10 +324,10 @@ class DicomClient:
         ds = Dataset()
         ds.QueryRetrieveLevel = "SERIES"
         ds.SeriesInstanceUID = series_instance_uid
-        
+
         # Associate with the DICOM node
         assoc = self.ae.associate(self.host, self.port, ae_title=self.called_aet)
-        
+
         if not assoc.is_established:
             return {
                 "success": False,
@@ -330,7 +336,7 @@ class DicomClient:
                 "failed": 0,
                 "warning": 0
             }
-        
+
         result = {
             "success": False,
             "message": "C-MOVE operation failed",
@@ -338,15 +344,15 @@ class DicomClient:
             "failed": 0,
             "warning": 0
         }
-        
+
         try:
             # Send C-MOVE request with the destination AE title
             responses = assoc.send_c_move(
-                ds, 
-                destination_ae, 
+                ds,
+                destination_ae,
                 PatientRootQueryRetrieveInformationModelMove
             )
-            
+
             # Process the responses
             for (status, dataset) in responses:
                 if status:
@@ -357,7 +363,7 @@ class DicomClient:
                         result["failed"] = status.NumberOfFailedSuboperations
                     if hasattr(status, 'NumberOfWarningSuboperations'):
                         result["warning"] = status.NumberOfWarningSuboperations
-                    
+
                     # Check the status code
                     if status.Status == 0x0000:  # Success
                         result["success"] = True
@@ -369,31 +375,31 @@ class DicomClient:
                         result["message"] = f"C-MOVE refused: Destination '{destination_ae}' unknown"
                     else:
                         result["message"] = f"C-MOVE failed with status 0x{status.Status:04X}"
-                        
+
                     # If we got a dataset with an error comment, add it
                     if dataset and hasattr(dataset, 'ErrorComment'):
                         result["message"] += f": {dataset.ErrorComment}"
-        
+
         finally:
             # Always release the association
             assoc.release()
-        
+
         return result
 
     def move_study(
-            self, 
+            self,
             destination_ae: str,
             study_instance_uid: str
         ) -> dict:
         """Move a DICOM study to another DICOM node using C-MOVE.
-        
+
         This method performs a simple C-MOVE operation to transfer a specific study
         to a destination DICOM node.
-        
+
         Args:
             destination_ae: AE title of the destination DICOM node
             study_instance_uid: Study Instance UID to be moved
-            
+
         Returns:
             Dictionary with operation status:
             {
@@ -408,10 +414,10 @@ class DicomClient:
         ds = Dataset()
         ds.QueryRetrieveLevel = "STUDY"
         ds.StudyInstanceUID = study_instance_uid
-        
+
         # Associate with the DICOM node
         assoc = self.ae.associate(self.host, self.port, ae_title=self.called_aet)
-        
+
         if not assoc.is_established:
             return {
                 "success": False,
@@ -420,7 +426,7 @@ class DicomClient:
                 "failed": 0,
                 "warning": 0
             }
-        
+
         result = {
             "success": False,
             "message": "C-MOVE operation failed",
@@ -428,15 +434,15 @@ class DicomClient:
             "failed": 0,
             "warning": 0
         }
-        
+
         try:
             # Send C-MOVE request with the destination AE title
             responses = assoc.send_c_move(
-                ds, 
-                destination_ae, 
+                ds,
+                destination_ae,
                 PatientRootQueryRetrieveInformationModelMove
             )
-            
+
             # Process the responses
             for (status, dataset) in responses:
                 if status:
@@ -447,7 +453,7 @@ class DicomClient:
                         result["failed"] = status.NumberOfFailedSuboperations
                     if hasattr(status, 'NumberOfWarningSuboperations'):
                         result["warning"] = status.NumberOfWarningSuboperations
-                    
+
                     # Check the status code
                     if status.Status == 0x0000:  # Success
                         result["success"] = True
@@ -459,32 +465,32 @@ class DicomClient:
                         result["message"] = f"C-MOVE refused: Destination '{destination_ae}' unknown"
                     else:
                         result["message"] = f"C-MOVE failed with status 0x{status.Status:04X}"
-                        
+
                     # If we got a dataset with an error comment, add it
                     if dataset and hasattr(dataset, 'ErrorComment'):
                         result["message"] += f": {dataset.ErrorComment}"
-        
+
         finally:
             # Always release the association
             assoc.release()
-        
+
         return result
     def extract_pdf_text_from_dicom(
-            self, 
+            self,
             study_instance_uid: str,
             series_instance_uid: str,
             sop_instance_uid: str
         ) -> Dict[str, Any]:
         """Retrieve a DICOM instance with encapsulated PDF and extract its text content.
-        
+
         This function retrieves a DICOM instance that contains an encapsulated PDF document
         using C-GET and extracts the PDF content using PyPDF2 to parse the text content.
-        
+
         Args:
             study_instance_uid: Study Instance UID
             series_instance_uid: Series Instance UID
             sop_instance_uid: SOP Instance UID
-            
+
         Returns:
             Dictionary with extracted text information and status:
             {
@@ -496,64 +502,64 @@ class DicomClient:
         """
         # Create temporary directory for storing retrieved files
         temp_dir = tempfile.mkdtemp()
-        
+
         # Create dataset for C-GET query
         ds = Dataset()
         ds.QueryRetrieveLevel = "IMAGE"
         ds.StudyInstanceUID = study_instance_uid
         ds.SeriesInstanceUID = series_instance_uid
         ds.SOPInstanceUID = sop_instance_uid
-        
+
         # Define a handler for C-STORE operations during C-GET
         received_files = []
-        
+
         def handle_store(event):
             """Handle C-STORE operations during C-GET"""
             ds = event.dataset
             sop_instance = ds.SOPInstanceUID if hasattr(ds, 'SOPInstanceUID') else "unknown"
-            
+
             # Ensure we have file meta information
             if not hasattr(ds, 'file_meta') or not hasattr(ds.file_meta, 'TransferSyntaxUID'):
                 from pydicom.dataset import FileMetaDataset
                 if not hasattr(ds, 'file_meta'):
                     ds.file_meta = FileMetaDataset()
-                
+
                 if event.context.transfer_syntax:
                     ds.file_meta.TransferSyntaxUID = event.context.transfer_syntax
                 else:
                     ds.file_meta.TransferSyntaxUID = "1.2.840.10008.1.2.1"
-                
+
                 if not hasattr(ds.file_meta, 'MediaStorageSOPClassUID') and hasattr(ds, 'SOPClassUID'):
                     ds.file_meta.MediaStorageSOPClassUID = ds.SOPClassUID
-                
+
                 if not hasattr(ds.file_meta, 'MediaStorageSOPInstanceUID') and hasattr(ds, 'SOPInstanceUID'):
                     ds.file_meta.MediaStorageSOPInstanceUID = ds.SOPInstanceUID
-            
+
             # Save the dataset to file
             file_path = os.path.join(temp_dir, f"{sop_instance}.dcm")
             ds.save_as(file_path, write_like_original=False)
             received_files.append(file_path)
-            
+
             return 0x0000  # Success
-        
+
         # Define event handlers - using the proper format for pynetdicom
         handlers = [(evt.EVT_C_STORE, handle_store)]
-        
+
         # Create an SCP/SCU Role Selection Negotiation item for PDF Storage
         # This is needed to indicate our AE can act as an SCP (receiver) for C-STORE operations
         # during the C-GET operation
         role = build_role(EncapsulatedPDFStorage, scp_role=True)
-        
+
         # Associate with the DICOM node, providing the event handlers during association
         # This is the correct way to handle events in pynetdicom
         assoc = self.ae.associate(
-            self.host, 
-            self.port, 
+            self.host,
+            self.port,
             ae_title=self.called_aet,
             evt_handlers=handlers,
             ext_neg=[role]  # Add extended negotiation for SCP/SCU role selection
         )
-        
+
         if not assoc.is_established:
             return {
                 "success": False,
@@ -561,20 +567,20 @@ class DicomClient:
                 "text_content": "",
                 "file_path": ""
             }
-        
+
         success = False
         message = "C-GET operation failed"
         pdf_path = ""
         extracted_text = ""
-        
+
         try:
             # Send C-GET request - without evt_handlers parameter since we provided them during association
             responses = assoc.send_c_get(ds, PatientRootQueryRetrieveInformationModelGet)
-            
+
             for (status, dataset) in responses:
                 if status:
                     status_int = status.Status if hasattr(status, 'Status') else 0
-                    
+
                     if status_int == 0x0000:  # Success
                         success = True
                         message = "C-GET operation completed successfully"
@@ -584,40 +590,40 @@ class DicomClient:
         finally:
             # Always release the association
             assoc.release()
-        
+
         # Process received files
         if received_files:
             dicom_file = received_files[0]
-            
+
             # Read the DICOM file
             ds = dcmread(dicom_file)
-            
+
             # Check if it's an encapsulated PDF
-            if (hasattr(ds, 'SOPClassUID') and 
+            if (hasattr(ds, 'SOPClassUID') and
                 ds.SOPClassUID == '1.2.840.10008.5.1.4.1.1.104.1'):  # Encapsulated PDF Storage
-                
+
                 # Extract the PDF data
                 pdf_data = ds.EncapsulatedDocument
-                
+
                 # Write to a temporary file
                 pdf_path = os.path.join(temp_dir, "extracted.pdf")
                 with open(pdf_path, 'wb') as pdf_file:
                     pdf_file.write(pdf_data)
-                
+
                 import PyPDF2
-                
+
                 # Extract text from the PDF
                 with open(pdf_path, 'rb') as pdf_file:
                     pdf_reader = PyPDF2.PdfReader(pdf_file)
                     text_parts = []
-                    
+
                     # Extract text from each page
                     for page_num in range(len(pdf_reader.pages)):
                         page = pdf_reader.pages[page_num]
                         text_parts.append(page.extract_text())
-                    
+
                     extracted_text = "\n".join(text_parts)
-                
+
                 return {
                     "success": True,
                     "message": "Successfully extracted text from PDF in DICOM",
@@ -627,27 +633,27 @@ class DicomClient:
             else:
                 message = "Retrieved DICOM instance does not contain an encapsulated PDF"
                 success = False
-        
+
         return {
             "success": success,
             "message": message,
             "text_content": extracted_text,
             "file_path": received_files[0] if received_files else ""
         }
-    
+
     @staticmethod
     def _dataset_to_dict(dataset: Dataset) -> Dict[str, Any]:
         """Convert a DICOM dataset to a dictionary.
-        
+
         Args:
             dataset: DICOM dataset
-            
+
         Returns:
             Dictionary representation of the dataset
         """
         if hasattr(dataset, "is_empty") and dataset.is_empty():
             return {}
-        
+
         result = {}
         for elem in dataset:
             if elem.VR == "SQ":
@@ -666,5 +672,5 @@ class DicomClient:
                     except Exception:
                         # Fall back to string representation
                         result[elem.keyword] = str(elem.value)
-        
+
         return result

--- a/src/dicom_mcp/dicom_storage.py
+++ b/src/dicom_mcp/dicom_storage.py
@@ -27,7 +27,7 @@ def _get_key_from_dataset(dataset: Dataset, key: str) -> str:
 
 
 class DicomStorage():
-    """Interface for storage of datasets"""
+    """In memory storage of dataset, that """
     def __init__(self, config: DicomConfiguration, logger: Logger) -> None:
         self.logger = logger
         self._internal_storage: PatientDict = {}
@@ -51,3 +51,29 @@ class DicomStorage():
 
         series = study_dict[series_key]
         series.append(dataset_to_store)
+
+    def retrive(
+            self,
+            patient_id=UNORGANIZED_DATASETS_KEY,
+            study_uid=UNORGANIZED_DATASETS_KEY,
+            series_key=UNORGANIZED_DATASETS_KEY,
+        ) -> List[Dataset]:
+
+        if patient_id not in self._internal_storage:
+
+            self.logger.info(f"Did not find any studies for {patient_id}")
+            return []
+
+        study_dict = self._internal_storage[patient_id]
+
+        if study_uid not in study_dict:
+            self.logger.info(f"Didn't find the study for {patient_id}")
+            return []
+
+        series_dict = study_dict[study_uid]
+
+        if series_key not in series_dict:
+            self.logger.info(f"Didn't find the series for {patient_id}")
+            return []
+
+        return series_dict[series_key]

--- a/src/dicom_mcp/dicom_storage.py
+++ b/src/dicom_mcp/dicom_storage.py
@@ -1,0 +1,53 @@
+# Standard library
+from logging import Logger
+from typing import Dict, List, TypeAlias
+
+
+
+import array
+# Third party
+from pydicom import Dataset
+
+from .config import DicomConfiguration
+
+
+SeriesDict: TypeAlias = Dict[str, List[Dataset]]
+StudyDict: TypeAlias = Dict[str, SeriesDict]
+PatientDict: TypeAlias = Dict[str, StudyDict]
+
+UNORGANIZED_DATASETS_KEY = "unorganized"
+
+def _get_key_from_dataset(dataset: Dataset, key: str) -> str:
+    DE = dataset.get(key, None)
+
+    if DE is not None:
+        return str(DE.value)
+
+    return UNORGANIZED_DATASETS_KEY
+
+
+class DicomStorage():
+    """Interface for storage of datasets"""
+    def __init__(self, config: DicomConfiguration, logger: Logger) -> None:
+        self.logger = logger
+        self._internal_storage: PatientDict = {}
+
+    def store(self, dataset_to_store: Dataset):
+        patient_key = _get_key_from_dataset(dataset_to_store, 'PatientID')
+
+        if patient_key not in dataset_to_store:
+            self._internal_storage = {}
+        patient_dict = self._internal_storage[patient_key]
+
+        study_key = _get_key_from_dataset(dataset_to_store, 'StudyInstanceUID')
+        if study_key not in patient_dict:
+            patient_dict[study_key] = {}
+
+        study_dict = patient_dict[study_key]
+
+        series_key = _get_key_from_dataset(dataset_to_store,'SeriesInstanceUID')
+        if series_key not in study_dict:
+            study_dict = {}
+
+        series = study_dict[series_key]
+        series.append(dataset_to_store)

--- a/src/dicom_mcp/server.py
+++ b/src/dicom_mcp/server.py
@@ -26,48 +26,40 @@ class DicomContext:
 
 def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMCP:
     """Create and configure a DICOM MCP server."""
-    
+
     # Define a simple lifespan function
     @asynccontextmanager
     async def lifespan(server: FastMCP) -> AsyncIterator[DicomContext]:
         # Load config
         config = load_config(config_path)
-        
-        # Get the current node and calling AE title
-        current_node = config.nodes[config.current_node]
-        
+
         # Create client
-        client = DicomClient(
-            host=current_node.host,
-            port=current_node.port,
-            calling_aet=config.calling_aet,
-            called_aet=current_node.ae_title
-        )
-        
+        client = DicomClient(config, logger)
+
         logger.info(f"DICOM client initialized: {config.current_node} (calling AE: {config.calling_aet})")
-        
+
         try:
             yield DicomContext(config=config, client=client)
         finally:
             pass
-    
+
     # Create server
     mcp = FastMCP(name, lifespan=lifespan)
-    
+
     # Register tools
     @mcp.tool()
     def list_dicom_nodes(ctx: Context = None) -> Dict[str, Any]:
         """List all configured DICOM nodes and their connection information.
-        
+
         This tool returns information about all configured DICOM nodes in the system
         and shows which node is currently selected for operations. It also provides
         information about available calling AE titles.
-        
+
         Returns:
             Dictionary containing:
             - current_node: The currently selected DICOM node name
             - nodes: List of all configured node names
-        
+
         Example:
             {
                 "current_node": "pacs1",
@@ -76,7 +68,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         """
         dicom_ctx = ctx.request_context.lifespan_context
         config = dicom_ctx.config
-        
+
         current_node =  config.current_node
         nodes = [{node_name: node.description} for node_name, node in config.nodes.items()]
 
@@ -84,7 +76,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             "current_node": current_node,
             "nodes": nodes,
         }
-    
+
     @mcp.tool()
     def extract_pdf_text_from_dicom(
         study_instance_uid: str,
@@ -93,24 +85,24 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         ctx: Context = None
     ) -> Dict[str, Any]:
         """Retrieve a DICOM instance with encapsulated PDF and extract its text content.
-        
+
         This tool retrieves a DICOM instance containing an encapsulated PDF document,
         extracts the PDF, and converts it to text. This is particularly useful for
         medical reports stored as PDFs within DICOM format (e.g., radiology reports,
         clinical documents).
-        
+
         Args:
             study_instance_uid: The unique identifier for the study (required)
             series_instance_uid: The unique identifier for the series within the study (required)
             sop_instance_uid: The unique identifier for the specific DICOM instance (required)
-        
+
         Returns:
             Dictionary containing:
             - success: Boolean indicating if the operation was successful
             - message: Description of the operation result or error
             - text_content: The extracted text from the PDF (if successful)
             - file_path: Path to the temporary DICOM file (for debugging purposes)
-        
+
         Example:
             {
                 "success": true,
@@ -121,7 +113,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client:DicomClient = dicom_ctx.client
-        
+
         return client.extract_pdf_text_from_dicom(
             study_instance_uid=study_instance_uid,
             series_instance_uid=series_instance_uid,
@@ -131,40 +123,40 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
     @mcp.tool()
     def switch_dicom_node(node_name: str, ctx: Context = None) -> Dict[str, Any]:
         """Switch the active DICOM node connection to a different configured node.
-        
+
         This tool changes which DICOM node (PACS, workstation, etc.) subsequent operations
         will connect to. The node must be defined in the configuration file.
-        
+
         Args:
             node_name: The name of the node to switch to, must match a name in the configuration
-        
+
         Returns:
             Dictionary containing:
             - success: Boolean indicating if the switch was successful
             - message: Description of the operation result or error
-        
+
         Example:
             {
                 "success": true,
                 "message": "Switched to DICOM node: orthanc"
             }
-        
+
         Raises:
             ValueError: If the specified node name is not found in configuration
-        """        
+        """
         dicom_ctx = ctx.request_context.lifespan_context
         config = dicom_ctx.config
-        
+
         # Check if node exists
         if node_name not in config.nodes:
             raise ValueError(f"Node '{node_name}' not found in configuration")
-        
+
         # Update configuration
         config.current_node = node_name
-        
+
         # Create a new client with the updated configuration
         current_node = config.nodes[config.current_node]
-        
+
         # Replace the client with a new instance
         dicom_ctx.client = DicomClient(
             host=current_node.host,
@@ -172,7 +164,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             calling_aet=config.calling_aet,
             called_aet=current_node.ae_title
         )
-        
+
         return {
             "success": True,
             "message": f"Switched to DICOM node: {node_name}"
@@ -181,39 +173,39 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
     @mcp.tool()
     def verify_connection(ctx: Context = None) -> str:
         """Verify connectivity to the current DICOM node using C-ECHO.
-        
+
         This tool performs a DICOM C-ECHO operation (similar to a network ping) to check
         if the currently selected DICOM node is reachable and responds correctly. This is
         useful to troubleshoot connection issues before attempting other operations.
-        
+
         Returns:
             A message describing the connection status, including host, port, and AE titles
-        
+
         Example:
             "Connection successful to 192.168.1.100:104 (Called AE: ORTHANC, Calling AE: CLIENT)"
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client = dicom_ctx.client
-        
+
         success, message = client.verify_connection()
         return message
 
     @mcp.tool()
     def query_patients(
-        name_pattern: str = "", 
-        patient_id: str = "", 
-        birth_date: str = "", 
-        attribute_preset: str = "standard", 
+        name_pattern: str = "",
+        patient_id: str = "",
+        birth_date: str = "",
+        attribute_preset: str = "standard",
         additional_attributes: List[str] = None,
-        exclude_attributes: List[str] = None, 
+        exclude_attributes: List[str] = None,
         ctx: Context = None
     ) -> List[Dict[str, Any]]:
         """Query patients matching the specified criteria from the DICOM node.
-        
+
         This tool performs a DICOM C-FIND operation at the PATIENT level to find patients
         matching the provided search criteria. All search parameters are optional and can
         be combined for more specific queries.
-        
+
         Args:
             name_pattern: Patient name pattern (can include wildcards * and ?), e.g., "SMITH*"
             patient_id: Patient ID to search for, e.g., "12345678"
@@ -224,10 +216,10 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                 - "extended": All available attributes
             additional_attributes: List of specific DICOM attributes to include beyond the preset
             exclude_attributes: List of DICOM attributes to exclude from the results
-        
+
         Returns:
             List of dictionaries, each representing a matched patient with their attributes
-        
+
         Example:
             [
                 {
@@ -237,13 +229,13 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                     "PatientSex": "M"
                 }
             ]
-        
+
         Raises:
             Exception: If there is an error communicating with the DICOM node
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client = dicom_ctx.client
-        
+
         try:
             return client.query_patient(
                 patient_id=patient_id,
@@ -258,23 +250,23 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
 
     @mcp.tool()
     def query_studies(
-        patient_id: str = "", 
-        study_date: str = "", 
+        patient_id: str = "",
+        study_date: str = "",
         modality_in_study: str = "",
-        study_description: str = "", 
-        accession_number: str = "", 
+        study_description: str = "",
+        accession_number: str = "",
         study_instance_uid: str = "",
-        attribute_preset: str = "standard", 
+        attribute_preset: str = "standard",
         additional_attributes: List[str] = None,
-        exclude_attributes: List[str] = None, 
+        exclude_attributes: List[str] = None,
         ctx: Context = None
     ) -> List[Dict[str, Any]]:
         """Query studies matching the specified criteria from the DICOM node.
-        
+
         This tool performs a DICOM C-FIND operation at the STUDY level to find studies
         matching the provided search criteria. All search parameters are optional and can
         be combined for more specific queries.
-        
+
         Args:
             patient_id: Patient ID to search for, e.g., "12345678"
             study_date: Study date or date range in DICOM format:
@@ -290,10 +282,10 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                 - "extended": All available attributes
             additional_attributes: List of specific DICOM attributes to include beyond the preset
             exclude_attributes: List of DICOM attributes to exclude from the results
-        
+
         Returns:
             List of dictionaries, each representing a matched study with its attributes
-        
+
         Example:
             [
                 {
@@ -305,13 +297,13 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                     "ModalitiesInStudy": "CT"
                 }
             ]
-        
+
         Raises:
             Exception: If there is an error communicating with the DICOM node
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client = dicom_ctx.client
-        
+
         try:
             return client.query_study(
                 patient_id=patient_id,
@@ -329,22 +321,22 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
 
     @mcp.tool()
     def query_series(
-        study_instance_uid: str, 
-        modality: str = "", 
+        study_instance_uid: str,
+        modality: str = "",
         series_number: str = "",
-        series_description: str = "", 
+        series_description: str = "",
         series_instance_uid: str = "",
-        attribute_preset: str = "standard", 
+        attribute_preset: str = "standard",
         additional_attributes: List[str] = None,
-        exclude_attributes: List[str] = None, 
+        exclude_attributes: List[str] = None,
         ctx: Context = None
     ) -> List[Dict[str, Any]]:
         """Query series within a study from the DICOM node.
-        
+
         This tool performs a DICOM C-FIND operation at the SERIES level to find series
         within a specified study. The study_instance_uid is required, and additional
         parameters can be used to filter the results.
-        
+
         Args:
             study_instance_uid: Unique identifier for the study (required)
             modality: Filter by imaging modality, e.g., "CT", "MR", "US", "CR"
@@ -357,10 +349,10 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                 - "extended": All available attributes
             additional_attributes: List of specific DICOM attributes to include beyond the preset
             exclude_attributes: List of DICOM attributes to exclude from the results
-        
+
         Returns:
             List of dictionaries, each representing a matched series with its attributes
-        
+
         Example:
             [
                 {
@@ -371,13 +363,13 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                     "NumberOfSeriesRelatedInstances": "120"
                 }
             ]
-        
+
         Raises:
             Exception: If there is an error communicating with the DICOM node
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client = dicom_ctx.client
-        
+
         try:
             return client.query_series(
                 study_instance_uid=study_instance_uid,
@@ -394,20 +386,20 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
 
     @mcp.tool()
     def query_instances(
-        series_instance_uid: str, 
-        instance_number: str = "", 
+        series_instance_uid: str,
+        instance_number: str = "",
         sop_instance_uid: str = "",
-        attribute_preset: str = "standard", 
+        attribute_preset: str = "standard",
         additional_attributes: List[str] = None,
-        exclude_attributes: List[str] = None, 
-        ctx: Context = None 
+        exclude_attributes: List[str] = None,
+        ctx: Context = None
     ) -> List[Dict[str, Any]]:
         """Query individual DICOM instances (images) within a series.
-        
+
         This tool performs a DICOM C-FIND operation at the IMAGE level to find individual
         DICOM instances within a specified series. The series_instance_uid is required,
         and additional parameters can be used to filter the results.
-        
+
         Args:
             series_instance_uid: Unique identifier for the series (required)
             instance_number: Filter by specific instance number within the series
@@ -418,10 +410,10 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                 - "extended": All available attributes
             additional_attributes: List of specific DICOM attributes to include beyond the preset
             exclude_attributes: List of DICOM attributes to exclude from the results
-        
+
         Returns:
             List of dictionaries, each representing a matched instance with its attributes
-        
+
         Example:
             [
                 {
@@ -432,13 +424,13 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
                     "ContentTime": "152245"
                 }
             ]
-        
+
         Raises:
             Exception: If there is an error communicating with the DICOM node
         """
         dicom_ctx = ctx.request_context.lifespan_context
         client = dicom_ctx.client
-        
+
         try:
             return client.query_instance(
                 series_instance_uid=series_instance_uid,
@@ -450,7 +442,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             )
         except Exception as e:
             raise Exception(f"Error querying instances: {str(e)}")
-        
+
     @mcp.tool()
     def move_series(
         destination_node: str,
@@ -458,14 +450,14 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         ctx: Context = None
     ) -> Dict[str, Any]:
         """Move a DICOM series to another DICOM node.
-        
-        This tool transfers a specific series from the current DICOM server to a 
+
+        This tool transfers a specific series from the current DICOM server to a
         destination DICOM node.
-        
+
         Args:
             destination_node: Name of the destination node as defined in the configuration
             series_instance_uid: The unique identifier for the series to be moved
-        
+
         Returns:
             Dictionary containing:
             - success: Boolean indicating if the operation was successful
@@ -473,7 +465,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             - completed: Number of successfully transferred instances
             - failed: Number of failed transfers
             - warning: Number of transfers with warnings
-        
+
         Example:
             {
                 "success": true,
@@ -486,20 +478,20 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         dicom_ctx = ctx.request_context.lifespan_context
         config = dicom_ctx.config
         client = dicom_ctx.client
-        
+
         # Check if destination node exists
         if destination_node not in config.nodes:
             raise ValueError(f"Destination node '{destination_node}' not found in configuration")
-        
+
         # Get the destination AE title
         destination_ae = config.nodes[destination_node].ae_title
-        
+
         # Execute the move operation
         result = client.move_series(
             destination_ae=destination_ae,
             series_instance_uid=series_instance_uid
         )
-        
+
         return result
 
     @mcp.tool()
@@ -509,14 +501,14 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         ctx: Context = None
     ) -> Dict[str, Any]:
         """Move a DICOM study to another DICOM node.
-        
-        This tool transfers an entire study from the current DICOM server to a 
+
+        This tool transfers an entire study from the current DICOM server to a
         destination DICOM node.
-        
+
         Args:
             destination_node: Name of the destination node as defined in the configuration
             study_instance_uid: The unique identifier for the study to be moved
-        
+
         Returns:
             Dictionary containing:
             - success: Boolean indicating if the operation was successful
@@ -524,7 +516,7 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             - completed: Number of successfully transferred instances
             - failed: Number of failed transfers
             - warning: Number of transfers with warnings
-        
+
         Example:
             {
                 "success": true,
@@ -537,36 +529,36 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
         dicom_ctx = ctx.request_context.lifespan_context
         config = dicom_ctx.config
         client = dicom_ctx.client
-        
+
         # Check if destination node exists
         if destination_node not in config.nodes:
             raise ValueError(f"Destination node '{destination_node}' not found in configuration")
-        
+
         # Get the destination AE title
         destination_ae = config.nodes[destination_node].ae_title
-        
+
         # Execute the move operation
         result = client.move_study(
             destination_ae=destination_ae,
             study_instance_uid=study_instance_uid
         )
-        
+
         return result
 
 
     @mcp.tool()
     def get_attribute_presets() -> Dict[str, Dict[str, List[str]]]:
         """Get all available attribute presets for DICOM queries.
-        
+
         This tool returns the defined attribute presets that can be used with the
         query_* functions. It shows which DICOM attributes are included in each
         preset (minimal, standard, extended) for each query level.
-        
+
         Returns:
             Dictionary organized by query level (patient, study, series, instance),
             with each level containing the attribute presets and their associated
             DICOM attributes.
-        
+
         Example:
             {
                 "patient": {
@@ -583,5 +575,5 @@ def create_dicom_mcp_server(config_path: str, name: str = "DICOM MCP") -> FastMC
             }
         """
         return ATTRIBUTE_PRESETS
-    
+
     return mcp


### PR DESCRIPTION
Hey Christian

This PR adds the ability for the DICOM mcp server to be able to retrieve datasets that it requested by a C-move.

Note that I don't quite think it's "production" ready because the current representation of a dicom series is very verbose, as many tags are repeated across the images.

Let me know if you want any changes.