### PR TITLE
Fix uv tool call in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Add to your client configuration (e.g. `claude_desktop_config.json`):
 {
   "mcpServers": {
     "dicom": {
-      "command": "uv",
-      "args": ["tool","dicom-mcp", "/path/to/your_config.yaml"]
+      "command": "uvx",
+      "args": ["dicom-mcp", "/path/to/your_config.yaml"]
     }
   }
 }


### PR DESCRIPTION
Can use `uv tool run dicom-mcp` or `uvx dicom-mcp`.

The current `uv tool dicom-mcp` results in "error: unrecognized subcommand 'dicom-mcp'"

https://docs.astral.sh/uv/guides/tools/#running-tools