### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,8 @@ npx @modelcontextprotocol/inspector uv run dicom-mcp /path/to/your_config.yaml -
 
 * Built using [pynetdicom](https://github.com/pydicom/pynetdicom)
 * Uses [PyPDF2](https://pypi.org/project/PyPDF2/) for PDF text extraction
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/christianhinge-dicom-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/christianhinge-dicom-mcp).